### PR TITLE
Add Hippocampus (Sample vault)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A curated list of awesome resources, templates, guides for developers, digital gardeners, and learners as an obsidian vault (basically markdown format with assets) that can be download and use it offline.
 
-## Table of vault + website classified by topics (49)
+## Table of vault + website classified by topics (50)
 
 > [!TIP]
 > ✨ marks a standout pick — a particularly polished, complete, or popular vault.
@@ -63,6 +63,7 @@ A curated list of awesome resources, templates, guides for developers, digital g
 | Personal Site    | Hundred Rabbits site                      | [vault](https://github.com/hundredrabbits/100r.co)                           | [web](https://100r.co/site/home.html)                                                  |   |
 | Personal Site    | Rekka Bellum (kokorobot)                  | [vault](https://github.com/rekkabell/kokorobot)                              | [web](https://kokorobot.ca/site/)                                                      |   |
 | Sample vault     | Ideaverse — LYT (Nick Milo)               | N/A                                                                          | [web](https://www.linkingyourthinking.com/ideaverse-for-obsidian/onboarding-ideaverse) |   |
+| Sample vault     | Hippocampus — Marc Sturlese               | [vault](https://github.com/sturlese/hippocampus)                             | N/A                                                                                    |   |
 | Web Directory    | Interneto — David7ce                      | [vault](https://github.com/interneto/interneto.github.io)                    | [web](https://interneto.github.io/)                                                    | ✨ |
 | Web Directory    | Free Media Heck Yeah — nbats              | [vault](https://github.com/fmhy/edit)                                        | [web](https://fmhy.net/)                                                               | ✨ |
 


### PR DESCRIPTION
Adds one row under **Sample vault** and bumps the section count from 49 to 50, per rule 6 in CONTRIBUTING.

| Category | Name and author | vault | web |
|---|---|---|---|
| Sample vault | Hippocampus — Marc Sturlese | https://github.com/sturlese/hippocampus | N/A |

**What it is:** a starter Obsidian vault that Claude Code maintains. You drop messy notes into `inbox/` and they get consolidated into typed, cross-linked pages under `wiki/` — flat YAML frontmatter, wikilinks, a master index and an append-only log. Based on Andrej Karpathy's LLM Wiki pattern.

**Why it may fit the list:** it is a downloadable, publicly accessible, Obsidian-compatible markdown vault, and it requires **no Obsidian plugins** — graph view, backlinks and Properties work out of the box. No vector database, no embeddings, no MCP servers and no third-party dependencies; the only executable is one stdlib Python linter that checks for dead wikilinks, orphan pages, duplicate names and index drift.

There is no published website, so `web` is `N/A`. Both links resolve (checked against lychee's usual failure modes: no redirects, no auth).

Em dash used between title and author, single spaces, ✨ column left blank.