### PR TITLE
Add Undercroft to Sample Vaults & Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A curated list of awesome resources, templates, guides for developers, digital g
 </style>
 -->
 
-## Vaults and websites grouped by topic (49)
+## Vaults and websites grouped by topic (50)
 
 > [!TIP]
 > ✨ marks a standout pick — a particularly polished, complete, or popular vault.
@@ -157,11 +157,12 @@ A curated list of awesome resources, templates, guides for developers, digital g
   </tbody>
   <tbody>
     <tr class="section-row">
-      <th rowspan="1" class="category-cell">Sample Vaults &amp; Templates</th>
+      <th rowspan="2" class="category-cell">Sample Vaults &amp; Templates</th>
       <td>Ideaverse — LYT (Nick Milo)</td>
       <td><a href="https://www.linkingyourthinking.com/ideaverse-for-obsidian/onboarding-ideaverse">web</a></td>
       <td></td>
     </tr>
+    <tr><td>Undercroft — Latticework Labs</td><td><a href="https://github.com/latticeworklabs-eng/undercroft">vault</a></td><td></td></tr>
   </tbody>
   <tbody>
     <tr class="section-row">


### PR DESCRIPTION
## What this adds

One row in **Sample Vaults & Templates**:

Undercroft — Latticework Labs · [vault](https://github.com/latticeworklabs-eng/undercroft)

Undercroft is a starter vault plus operating schema for an LLM-maintained personal wiki: plain Markdown with `[[wikilinks]]`, Obsidian-compatible, MIT-licensed. The repo ships a `starter/` skeleton (index, changelog, raw/wiki layers), the `CLAUDE.md` contract that Claude Code follows to maintain the vault, and a worked `example/` ingest (a Paul Graham essay turned into cross-linked source/entity/concept pages) you can browse as a vault.

## Disclosure

I'm the author — this is a self-submission from the project's own account. Happy to have it judged on the formatting rules and scope criteria; feel free to close if it doesn't fit the bar.

## Formatting rules from CONTRIBUTING.md

- Reused an existing category (Sample Vaults & Templates), row grouped with it; alphabetical after Ideaverse
- Em dash between title and author, single spaces
- vault link points to the public Git repo; no published web version, so no web link
- Left the sparkle column blank (maintainer's call)
- Updated the section-heading count from 49 to 50 and bumped the category rowspan from 1 to 2
- Link resolves (public repo), so the lychee check should pass