### PR TITLE
Add Solo OS Lite to Sample Vaults & Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A curated list of awesome resources, templates, guides for developers, digital g
 </style>
 -->
 
-## Vaults and websites grouped by topic (52)
+## Vaults and websites grouped by topic (53)
 
 > [!TIP]
 > ✨ marks a standout pick — a particularly polished, complete, or popular vault.
@@ -158,12 +158,13 @@ A curated list of awesome resources, templates, guides for developers, digital g
   </tbody>
   <tbody>
     <tr class="section-row">
-      <th rowspan="3" class="category-cell">Sample Vaults &amp; Templates</th>
+      <th rowspan="4" class="category-cell">Sample Vaults &amp; Templates</th>
       <td>Ideaverse — LYT (Nick Milo)</td>
       <td><a href="https://www.linkingyourthinking.com/ideaverse-for-obsidian/onboarding-ideaverse">web</a></td>
       <td></td>
     </tr>
     <tr><td>Second Brain Starter — secondbrainstarter</td><td><a href="https://github.com/secondbrainstarter/second-brain-starter">vault</a> / <a href="https://secondbrainstarter.github.io/">web</a></td><td></td></tr>
+    <tr><td>Solo OS Lite — mikroconsult</td><td><a href="https://mikroconsult.gumroad.com/l/solo-os-lite">vault</a></td><td></td></tr>
     <tr><td>Undercroft — Latticework Labs</td><td><a href="https://github.com/latticeworklabs-eng/undercroft">vault</a></td><td></td></tr>
   </tbody>
   <tbody>


### PR DESCRIPTION
Adds Solo OS Lite under Sample Vaults & Templates.

It is a free markdown vault (daily note, weekly review, one ship) that works in Obsidian or any folder. Download: https://mikroconsult.gumroad.com/l/solo-os-lite ($0 checkout).

Count in the heading is updated 52 → 53. ✨ column left blank.